### PR TITLE
Get deploy code by hash of fully qualified contract name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ ast.functions_in_contract_by_name('BlackScholesEstimate', name_only=True)
 ast.source_by_pc('BlackScholesEstimate', 92)
 
 # Get deployment code by contract name
-ast.get_deploy_bin('BlackScholesEstimate')
+ast.get_deploy_bin_by_contract_name('BlackScholesEstimate')
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # An AST parser for solc json outputs
 
-## Usage 
+## Usage
 
 Parsing AST with solidity source code and get contract information:
 
@@ -16,5 +16,7 @@ ast.functions_in_contract_by_name('BlackScholesEstimate', name_only=True)
 
 # Get source code by program counter
 ast.source_by_pc('BlackScholesEstimate', 92)
-```
 
+# Get deployment code by contract name
+ast.get_deploy_bin('BlackScholesEstimate')
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 addict==2.4.0
 py_solc_x==1.1.1
+pycryptodome==3.16.0
 semantic_version==2.9.0
-utils==1.0.1
+setuptools==65.5.0

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,9 @@ setup(
     install_requires=['addict>=2.4.0',
                       'py_solc_x>=1.1.1',
                       'semantic_version>=2.9.0',
+                      'pycryptodome>=3.16.0',
                       'utils>=1.0.1'],
     setup_requires=['pytest-runner'],
     tests_require=['pytest>-4.4.1'],
-    test_suite='tests',    
+    test_suite='tests',
 )

--- a/solc_json_parser/parser.py
+++ b/solc_json_parser/parser.py
@@ -8,7 +8,7 @@ import solcx
 import json
 import os
 import re
-from typing import Collection, Dict, Optional, List, Iterable, Any, Tuple, Union
+from typing import Collection, Dict, Optional, List, Any, Tuple, Union
 from functools import cached_property, cache
 from Crypto.Hash import keccak
 
@@ -798,9 +798,6 @@ class SolidityAst():
         linenums = (source_as_bytes[:begin].decode().count('\n') + 1,
                     source_as_bytes[:end].decode().count('\n') + 1)
         return dict(pc=pc, fragment=fragment, begin=begin, end=end, linenums=linenums, source_idx=source, source_path=(source_path or self.file_path))
-
-    def get_compiled_data(self, *keys) -> Optional[Any]:
-        return get_in(self.solc_json_ast, *keys)
 
     def get_deploy_bin_by_contract_name(self, contract_name: str) -> Optional[str]:
         return get_in(self.solc_json_ast, contract_name, 'bin')


### PR DESCRIPTION
Adds `get_deploy_bin_by_hash(hash)` to get contract or library deploy binary by [hash of fully qualified contract or library name](https://docs.soliditylang.org/en/v0.8.16/using-the-compiler.html#library-linking).

