### PR TITLE
Fix line mapping issue

### DIFF
--- a/solc_json_parser/parser.py
+++ b/solc_json_parser/parser.py
@@ -184,6 +184,61 @@ class SolidityAst():
     FUNC_VISIBILITY_NON_PRIVATE = frozenset(('external', 'internal', 'public'))
 
     def __init__(self, contract_source_path: str, version=None, retry_num=None, solc_options={}):
+        '''
+    Compile the input contract and create a SolidityAst object.
+
+    Parameters:
+    contract_source_path: str, required
+        a path to the solidity source file or source code as string.
+    version:  str, optional
+        solc version to use for compile the contract. If not provided will use auto detected solc version.
+        Note that SolidityAst will try to compile the contract starting from the lowest detected solc version first, increase the solc version each time when compilation fails.
+    retry_num: int, optional
+        Maximum number of solc versions to try to compile the contract
+
+
+    solc_options: Dict, optional
+    The optionsl passed to the solc compiler, the following options are supports:
+    base_path : Path | str, optional
+        Use the given path as the root of the source tree instead of the root
+        of the filesystem.
+    allow_paths : List | Path | str, optional
+        A path, or list of paths, to allow for imports.
+    output_dir : str, optional
+        Creates one file per component and contract/file at the specified directory.
+    overwrite : bool, optional
+        Overwrite existing files (used in combination with `output_dir`)
+    evm_version: str, optional
+        Select the desired EVM version. Valid options depend on the `solc` version.
+    revert_strings : List | str, optional
+        Strip revert (and require) reason strings or add additional debugging
+        information.
+    metadata_hash : str, optional
+        Choose hash method for the bytecode metadata or disable it.
+    metadata_literal : bool, optional
+        Store referenced sources as literal data in the metadata output.
+    optimize : bool, optional
+        Enable bytecode optimizer.
+    optimize_runs : int, optional
+        Set for how many contract runs to optimize. Lower values will optimize
+        more for initial deployment cost, higher values will optimize more for
+        high-frequency usage.
+    optimize_yul: bool, optional
+        Enable the yul optimizer.
+    no_optimize_yul : bool, optional
+        Disable the yul optimizer.
+    yul_optimizations : int, optional
+        Force yul optimizer to use the specified sequence of optimization steps
+        instead of the built-in one.
+    solc_binary : str | Path, optional
+        Path of the `solc` binary to use. If not given, the currently active
+        version is used (as set by `solcx.set_solc_version`)
+    solc_version: Version, optional
+        `solc` version to use. If not given, the currently active version is used.
+        Ignored if `solc_binary` is also given.
+    allow_empty : bool, optional
+        If `True`, do not raise when no compiled contracts are returned.
+        '''
         if '\n' in contract_source_path:
             self.source = contract_source_path
             self.file_path = None
@@ -844,7 +899,7 @@ class SolidityAst():
         else:
             source_code = self.source
         return source_code
-    
+
     def source_by_pc(self, contract_name: str, pc: int, deploy=False) -> Dict[str, Any]:
         '''
         Get source code by program counter:

--- a/tests/test_contracts/test_with_exp_abi.sol
+++ b/tests/test_contracts/test_with_exp_abi.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.7.6;
+pragma experimental ABIEncoderV2;
+
+contract Test {
+  struct Sig { uint8 v; bytes32 r; bytes32 s;}
+
+  function claim(bytes32 _msg, Sig memory sig) public {
+    address signer = ecrecover(_msg, sig.v, sig.r, sig.s);
+    // require(signer == owner);
+    payable(msg.sender).transfer(address(this).balance);
+  }
+
+  function vec_add(uint[2] memory a, uint[2] memory b) public returns (uint[2] memory c){
+    c[0] = a[0] + b[0]; //overflow
+    c[1] = a[1] + b[1]; //overflow
+  }
+}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -354,7 +354,7 @@ class TestParser(unittest.TestCase):
             self.assertEqual(func1.raw, func2.raw)
 
         for v in ['0.6.0', '0.7.0', '0.8.7']:
-            ast = SolidityAst(f'{contracts_root}/dev/1_BaseStorage.sol', version=v,
+            ast = SolidityAst(f'{contracts_root}/dev/1_BaseStorage.sol', version=v, 
                               solc_options={'allow_paths': f''})
             sub_test(ast)
 
@@ -363,8 +363,3 @@ class TestParser(unittest.TestCase):
                               solc_options={'allow_paths': f'', 'base_path': f'{contracts_root}'})
             sub_test(ast)
 
-
-    def test_source_by_pc(self):
-        ast = SolidityAst(f'{contracts_root}/dev/1_BaseStorage.sol', solc_options={'optimize': True, 'optimize_runs': 200})
-        source = ast.source_by_pc('Test', 278, False)
-        print(f'source: {source}')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -354,7 +354,7 @@ class TestParser(unittest.TestCase):
             self.assertEqual(func1.raw, func2.raw)
 
         for v in ['0.6.0', '0.7.0', '0.8.7']:
-            ast = SolidityAst(f'{contracts_root}/dev/1_BaseStorage.sol', version=v, 
+            ast = SolidityAst(f'{contracts_root}/dev/1_BaseStorage.sol', version=v,
                               solc_options={'allow_paths': f''})
             sub_test(ast)
 
@@ -363,3 +363,8 @@ class TestParser(unittest.TestCase):
                               solc_options={'allow_paths': f'', 'base_path': f'{contracts_root}'})
             sub_test(ast)
 
+
+    def test_source_by_pc(self):
+        ast = SolidityAst(f'{contracts_root}/dev/1_BaseStorage.sol', solc_options={'optimize': True, 'optimize_runs': 200})
+        source = ast.source_by_pc('Test', 278, False)
+        print(f'source: {source}')

--- a/tests/test_source_by_pc.py
+++ b/tests/test_source_by_pc.py
@@ -1,48 +1,59 @@
 import unittest
 from solc_json_parser.parser import SolidityAst, get_in
+from typing import Dict, Any, List
+
+
+class TestCase():
+    def __init__(self, source: str, contract: str, use_deploy_code: bool, expected_pc_start_lines = List, solc_options: Dict={}):
+        self.source = source
+        self.contract = contract
+        self.use_deploy_code = use_deploy_code
+        self.solc_options = solc_options
+        self.expected_pc_start_lines = expected_pc_start_lines
 
 class TestSourceByPc(unittest.TestCase):
     def test_source_by_pc_single_source(self):
         test_cases = [
-            ('./tests/test_contracts/IntegerOverflow.sol',
-             'IntegerOverflow',
-             False,
-             ((333, 9),
-              (383, 11),
-              (85, 19),
-              (321, 16),
-              (338, 9),
-              (377, 10),)),
-            ('./tests/test_contracts/ms/MultiSourceLib.sol',
-             'MultiSourceUtils',
-             False,
-             ((123, 15),))
-        ]
-        for (path, contract, use_deploy_code, lns) in test_cases:
-            ast = SolidityAst(path)
-            for (pc, linenum) in lns:
-                frag = ast.source_by_pc(contract, pc, use_deploy_code)
+            TestCase('./tests/test_contracts/IntegerOverflow.sol',
+                     'IntegerOverflow',
+                     False,
+                     [(333, 9),
+                      (383, 11),
+                      (85, 19),
+                      (321, 16),
+                      (338, 9),
+                      (377, 10),]),
+            TestCase('./tests/test_contracts/ms/MultiSourceLib.sol',
+                     'MultiSourceUtils',
+                     False,
+                     [(123, 15),]),
+            TestCase('./tests/test_contracts/test_with_exp_abi.sol',
+                     'Test',
+                     False,
+                     [(278, 15),
+                      (293, 16)],
+                     {'optimize': True, 'optimize_runs': 200})]
+        for t in test_cases:
+            ast = SolidityAst(t.source, solc_options=t.solc_options)
+            for (pc, linenum) in t.expected_pc_start_lines:
+                frag = ast.source_by_pc(t.contract, pc, t.use_deploy_code)
                 ln = get_in(frag, 'linenums', 0)
-                self.assertEqual(linenum, ln, f'Fail with contract {contract} in {path}')
+                self.assertEqual(linenum, ln, f'Fail with contract {t.contract} in {t.source} with options {t.solc_options}, got fragment: {frag}')
 
     def test_source_by_pc_multiple_sources(self):
         test_cases = [
-            ('./tests/test_contracts/ms/MultiSource.sol',
-             'MultiSourceUtils',
-             False,
-             (
-                 (123, 15),
-              )),
-            ('./tests/test_contracts/ms/MultiSource.sol',
-             'MultiSource',
-             False,
-             (
-                 (132, 17),
-              )),
+            TestCase('./tests/test_contracts/ms/MultiSource.sol',
+                     'MultiSourceUtils',
+                     False,
+                     [(123, 15),]),
+            TestCase('./tests/test_contracts/ms/MultiSource.sol',
+                     'MultiSource',
+                     False,
+                     [(132, 17),]),
         ]
-        for (path, contract, use_deploy_code, lns) in test_cases:
-            ast = SolidityAst(path)
-            for (pc, linenum) in lns:
-                frag = ast.source_by_pc(contract, pc, use_deploy_code)
+        for t in test_cases:
+            ast = SolidityAst(t.source)
+            for (pc, linenum) in t.expected_pc_start_lines:
+                frag = ast.source_by_pc(t.contract, pc, t.use_deploy_code)
                 ln = get_in(frag, 'linenums', 0)
-                self.assertEqual(linenum, ln, f'Fail with contract {contract} in {path} {frag}')
+                self.assertEqual(linenum, ln, f'Fail with contract {t.contract} in {t.source} with options {t.solc_options}, got fragment: {frag}')


### PR DESCRIPTION
Correct line mapping requires consistent solc compiler options. This PR accepts the `solc_options` from SolidityAst constructor. Note that these options set in `solc_options` have no effect as they will be overwritten by automatically configured values:

- base_path
- import_remappings
- output_values
- solc_version