### PR TITLE
prevent potential exception throwing

### DIFF
--- a/solc_json_parser/parser.py
+++ b/solc_json_parser/parser.py
@@ -992,34 +992,37 @@ class SolidityAst():
     def _process_literal_node(literals_nodes, only_value):
         literals = dict(number=set(), string=set(), address=set(), other=set())
         for literal in literals_nodes:
-            if literal.sub_type is None and literal.token_type == 'number':
-                if only_value and literal.str_value.isdecimal():
-                    literals['number'].add(int(literal.str_value))
+            try:
+                if literal.sub_type is None and literal.token_type == 'number':
+                    if only_value and literal.str_value.isdecimal():
+                        literals['number'].add(int(literal.str_value))
+                    else:
+                        literals['number'].add(literal)
+                elif literal.sub_type.startswith("address"):
+                    if only_value:
+                        literals['address'].add(literal.str_value)
+                    else:
+                        literals['address'].add(literal)
+                elif literal.sub_type.startswith("int"):
+                    if only_value:
+                        literals['number'].add(int(literal.sub_type.split(' ')[1]))
+                    else:
+                        literals['number'].add(literal)
+                # check if string in token_type, ignore case
+                elif literal.sub_type.startswith("literal_string"):
+                    if only_value:
+                        literals['string'].add(literal.str_value)
+                    else:
+                        literals['string'].add(literal)
+                elif literal.sub_type.startswith("bool"):
+                    continue
                 else:
-                    literals['number'].add(literal)
-            elif literal.sub_type.startswith("address"):
-                if only_value:
-                    literals['address'].add(literal.str_value)
-                else:
-                    literals['address'].add(literal)
-            elif literal.sub_type.startswith("int"):
-                if only_value:
-                    literals['number'].add(int(literal.sub_type.split(' ')[1]))
-                else:
-                    literals['number'].add(literal)
-            # check if string in token_type, ignore case
-            elif literal.sub_type.startswith("literal_string"):
-                if only_value:
-                    literals['string'].add(literal.str_value)
-                else:
-                    literals['string'].add(literal)
-            elif literal.sub_type.startswith("bool"):
+                    if only_value:
+                        literals['other'].add(literal.str_value)
+                    else:
+                        literals['other'].add(literal)
+            except:
                 continue
-            else:
-                if only_value:
-                    literals['other'].add(literal.str_value)
-                else:
-                    literals['other'].add(literal)
         return literals
 
     def _traverse_nodes(self, node, literals_nodes):


### PR DESCRIPTION
```solidity
contract BugSample {
    uint256 uzero = 0;
    uint256 umax = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
    uint256 umax2 = 0xffffffffffffffffffffffffffffffffffffffffff;
    uint256 guards = 1;
    uint256 test3 = 1234567890;
    address winner;
    address owner;
    bool reentrancy_guard = false;

    function test () public {

    }
}
```

The value in sub_type is omitted hence the literals value parsing failed.  I think we should not allow throwing exception in these kind of utilities functions. The bug still needs fixing after this PR btw. 

```
  File "solc-json-parser/solc_json_parser/parser.py", line 1068, in get_literals
    literals = self._process_literal_node(literals_nodes, only_value)
  File "solc-json-parser/solc_json_parser/parser.py", line 1008, in _process_literal_node
    literals['number'].add(int(literal.sub_type.split(' ')[1]))
ValueError: invalid literal for int() with base 10: '1157...(70'

literal  Literal(token_type='number', sub_type='int_const 1157...(70 digits omitted)...9935', str_value='0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff', hex_value='307866666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666')
```