### PR TITLE
fix missing address literals

### DIFF
--- a/solc_json_parser/parser.py
+++ b/solc_json_parser/parser.py
@@ -1043,7 +1043,10 @@ class SolidityAst():
                 elif literal.sub_type.startswith("int"):
                     if only_value:
                         if literal.str_value.startswith('0x'):
-                            literals['number'].add(int(literal.str_value, 16))
+                            if 40 <= len(literal.str_value) <= 42:
+                                literals['address'].add(literal.str_value)
+                            else:
+                                literals['number'].add(int(literal.str_value, 16))
                         elif literal.sub_type.split()[1].isdecimal():
                             literals['number'].add(int(literal.sub_type.split()[1]))
                         else:


### PR DESCRIPTION
Error when parsing some contract the address literals parsed as int const  sub_type

https://github.com/smartbugs/smartbugs-curated/blob/618cc4b670220fea76c47284998eaf4be4d10433/dataset/unchecked_low_level_calls/0x9d06cbafa865037a01d322d3f4222fa3e04e5488.sol#L24-L26

```
==> Literal(token_type='number', sub_type='int_const 6882...(40 digits omitted)...9008', str_value='0x788c45dd60ae4dbe5055b5ac02384d5dc84677b0', hex_value='307837383863343564643630616534646265353035356235616330323338346435646338343637376230')
Literal(token_type='number', sub_type='address', str_value='0x0C6561edad2017c01579Fd346a58197ea01A0Cf3', hex_value='307830433635363165646164323031376330313537394664333436613538313937656130314130436633')
Literal(token_type='number', sub_type='address', str_value='0xF85A2E95FA30d005F629cBe6c6d2887D979ffF2A', hex_value='307846383541324539354641333064303035463632396342653663366432383837443937396666463241')
```