### PR TITLE
Update to use in smart-fuzz

### DIFF
--- a/solc_json_parser/base_parser.py
+++ b/solc_json_parser/base_parser.py
@@ -171,7 +171,7 @@ class BaseParser():
                         modifiers=modifiers, line_num=line_number_range, state_mutability=state_mutability,
                         source_id=node.get("source_id"))
 
-    def get_yul_lines(self, contract_name: str, deploy: bool) -> List[str]:
+    def get_yul_lines(self, contract_name: str, deploy: Optional[bool]=False) -> List[str]:
         if not self.v8:
             return []
 
@@ -373,7 +373,7 @@ class BaseParser():
         contracts = self.all_contracts()
         base_contract_ids = set([bc for c in contracts for bc in c.base_contracts])
         names = list(filter(None, map(self.id_to_symbols.get, base_contract_ids)))
-        if len(set(names)) == len(base_contract_ids):
+        if len(set(names)) != len(base_contract_ids):
             print(f'Possibly different contracts with same name, or complilation with remappings: {self.id_to_symbols} {base_contract_ids}, {names}')
         return names
 

--- a/solc_json_parser/standard_json_parser.py
+++ b/solc_json_parser/standard_json_parser.py
@@ -7,7 +7,8 @@ from .version_cfg import v_keys
 from . import ast_shared as s
 from .ast_shared import SolidityAstError, solc_bin
 from .base_parser import BaseParser
-from .fields import Field, Function, ContractData, Modifier, Event, Literal
+from .fields import Function
+import sys
 
 def node_contains(src_str: str, pc_source: dict) -> bool:
     """
@@ -196,6 +197,12 @@ class StandardJsonParser(BaseParser):
                  solc_options: Optional[Dict] = {}):
         if retry_num is not None and retry_num > 0:
             raise Exception('StandardJsonParser does not support retry')
+
+        if try_install_solc:
+            print('StandardJsonParser does not support try_install_solc, option will be ignored', file=sys.stderr)
+
+        if solc_options:
+            print('StandardJsonParser does not support solc_options, please set extra parameters to input_json instead', file=sys.stderr)
 
         super().__init__()
         self.file_path = None

--- a/solc_json_parser/standard_json_parser.py
+++ b/solc_json_parser/standard_json_parser.py
@@ -483,11 +483,22 @@ class StandardJsonParser(BaseParser):
 
     def source_path_by_contract(self, contract_name: str) -> str:
         """
-        Get source path by contract name. Note: May throw exception. May return unexpected result when the contract appears in multiple source files.
+        Get source path by contract name.
+        Note:
+        - May throw exception if no source file contains the contract.
+        - May return unexpected result when the contract appears in multiple source files.
         """
         pred = lambda node: node and node.get('nodeType') == 'ContractDefinition' and node.get('name') == contract_name
         contract = self.__extract_node(pred, self.output_json['sources'], first_only=True)[0]
         return contract['source_id']
+
+    def all_source_path_by_contract(self, contract_name: str) -> Optional[List[str]]:
+        """
+        Get source path by contract name.
+        """
+        pred = lambda node: node and node.get('nodeType') == 'ContractDefinition' and node.get('name') == contract_name
+        contracts = self.__extract_node(pred, self.output_json['sources'], first_only=False)
+        return [c['source_id'] for c in contracts] if contracts else []
 
     def source_by_lines(self, contract_name: str, line_start: int, line_end: int) -> str:
         """

--- a/solc_json_parser/standard_json_parser.py
+++ b/solc_json_parser/standard_json_parser.py
@@ -107,7 +107,7 @@ def source_content_by_file_key(input_json: dict, filename: str):
     return s.get_in(input_json, 'sources', filename, 'content')
 
 def filename_by_fid(output_json: dict, fid: int) -> str:
-    filename = ''
+
     for k, source in output_json['sources'].items():
         if fid == source['id']:
             filename = k
@@ -480,3 +480,20 @@ class StandardJsonParser(BaseParser):
         literals = s.process_literal_node(literals_nodes, only_value)
 
         return literals
+
+    def source_path_by_contract(self, contract_name: str) -> str:
+        """
+        Get source path by contract name. Note: May throw exception. May return unexpected result when the contract appears in multiple source files.
+        """
+        pred = lambda node: node and node.get('nodeType') == 'ContractDefinition' and node.get('name') == contract_name
+        contract = self.__extract_node(pred, self.output_json['sources'], first_only=True)[0]
+        return contract['source_id']
+
+    def source_by_lines(self, contract_name: str, line_start: int, line_end: int) -> str:
+        """
+        Get source code by contract name and line numbers, line numbers are zero indexed
+        """
+        source_path = self.source_path_by_contract(contract_name)
+        content = self.input_json['sources'][source_path]['content']
+        lines = content.split('\n')[line_start:line_end]
+        return '\n'.join(lines)


### PR DESCRIPTION
updates 
- [x] source_by_lines
- [x] source_by_pc returns None in some cases (test_dos.sol): return yul fragment when source id exists but not found in the solidity source code 
